### PR TITLE
Get the list of genres always returns error invalid type

### DIFF
--- a/src/API/index.js
+++ b/src/API/index.js
@@ -163,7 +163,7 @@ class API {
          * @returns {Promise<ResourceResponse | ErrorResponse>}
          */
         Get: async(version = "1.0", type) => {
-            if(!type) throw new Error("You must provide a valid type");
+            if(!Objects.values(Enums.AnimeResourceType).includes(type)) throw new Error("You must provide a valid type");
             return this.api({
                 method: "GET",
                 url: `/resources/${version}/${type}`


### PR DESCRIPTION
Hi 😊,

Recently, I have used this library. And I encountered an issue, the list of genres not be retrieved from the API.

Then, after looking through the source code. I found that the function for fetching the resource has a condition to validate the type of resource with `if(!type)`. So if I want to get the list of genres, but its enum is 0. That makes this condition will always be false.

To fix this issue I change this validation by checking with its enums.